### PR TITLE
Fix query limitation in GetAllProjects in SonarServer.java

### DIFF
--- a/src/main/java/org/intellij/sonar/sonarserver/SonarServer.java
+++ b/src/main/java/org/intellij/sonar/sonarserver/SonarServer.java
@@ -141,7 +141,8 @@ public class SonarServer {
 
     public List<Component> getAllProjects(WsClient sonarClient) {
         org.sonarqube.ws.client.component.SearchWsRequest query = new org.sonarqube.ws.client.component.SearchWsRequest()
-                .setQualifiers(singletonList(SonarQualifier.PROJECT.getQualifier()));
+                .setQualifiers(singletonList(SonarQualifier.PROJECT.getQualifier()))
+                .setPageSize(-1);
         return sonarClient.components().search(query).getComponentsList();
     }
 

--- a/src/main/java/org/intellij/sonar/sonarserver/SonarServer.java
+++ b/src/main/java/org/intellij/sonar/sonarserver/SonarServer.java
@@ -142,7 +142,7 @@ public class SonarServer {
     public List<Component> getAllProjects(WsClient sonarClient) {
         org.sonarqube.ws.client.component.SearchWsRequest query = new org.sonarqube.ws.client.component.SearchWsRequest()
                 .setQualifiers(singletonList(SonarQualifier.PROJECT.getQualifier()))
-                .setPageSize(-1);
+                .setPageSize(10000); //-1 is not allowed, neither int max. The limit is 10000.
         return sonarClient.components().search(query).getComponentsList();
     }
 


### PR DESCRIPTION
Set pageSize to 10000 for project query to receive all project not only the top 100.