### PR TITLE
Possible update for 2020.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.jetbrains.intellij" version "0.3.12"
+    id "org.jetbrains.intellij" version "0.4.21"
     id "org.sonarqube" version "2.8"
 }
 
@@ -14,10 +14,10 @@ repositories {
     mavenCentral()
 }
 
-version = '2.8.4'
+version = '2.9.0'
 
 intellij {
-    version '2019.3'
+    version '2020.1'
 }
 
 dependencies {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Fri May 22 03:23:34 CEST 2020
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/org/intellij/sonar/analysis/SonarQubeInspectionExtensionsFactory.java
+++ b/src/main/java/org/intellij/sonar/analysis/SonarQubeInspectionExtensionsFactory.java
@@ -33,7 +33,7 @@ import org.jetbrains.annotations.Nullable;
 public class SonarQubeInspectionExtensionsFactory extends InspectionExtensionsFactory {
 
   @Override
-  public GlobalInspectionContextExtension createGlobalInspectionContextExtension() {
+  public GlobalInspectionContextExtension<SonarQubeInspectionContext> createGlobalInspectionContextExtension() {
     return new SonarQubeInspectionContext();
   }
 

--- a/src/main/java/org/intellij/sonar/configuration/module/ModuleLocalAnalysisScriptView.java
+++ b/src/main/java/org/intellij/sonar/configuration/module/ModuleLocalAnalysisScriptView.java
@@ -1,15 +1,15 @@
 package org.intellij.sonar.configuration.module;
 
-import static org.intellij.sonar.util.UIUtil.makeObj;
-
-import java.util.Collection;
-
-import javax.swing.*;
-
 import com.intellij.openapi.project.Project;
 import org.intellij.sonar.configuration.partials.LocalAnalysisScriptView;
 import org.intellij.sonar.persistence.LocalAnalysisScript;
 import org.intellij.sonar.persistence.LocalAnalysisScripts;
+
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import java.util.Collection;
+
+import static org.intellij.sonar.util.UIUtil.makeObj;
 
 public class ModuleLocalAnalysisScriptView extends LocalAnalysisScriptView {
 
@@ -40,14 +40,8 @@ public class ModuleLocalAnalysisScriptView extends LocalAnalysisScriptView {
   }
 
   protected boolean editAndRemoveButtonsCanBeEnabled() {
-    final boolean isNoLocalAnalysis = LocalAnalysisScripts.NO_LOCAL_ANALYSIS.equals(
-      myLocalAnalysisScriptComboBox.getSelectedItem()
-        .toString()
-    );
-    final boolean isProject = LocalAnalysisScripts.PROJECT.equals(
-      myLocalAnalysisScriptComboBox.getSelectedItem()
-        .toString()
-    );
+    final boolean isNoLocalAnalysis = LocalAnalysisScripts.NO_LOCAL_ANALYSIS.equals(String.valueOf(myLocalAnalysisScriptComboBox.getSelectedItem()));
+    final boolean isProject = LocalAnalysisScripts.PROJECT.equals(String.valueOf(myLocalAnalysisScriptComboBox.getSelectedItem()));
     return !isNoLocalAnalysis && !isProject;
   }
 }

--- a/src/main/java/org/intellij/sonar/configuration/module/ModuleSettingsConfigurable.java
+++ b/src/main/java/org/intellij/sonar/configuration/module/ModuleSettingsConfigurable.java
@@ -132,7 +132,7 @@ public class ModuleSettingsConfigurable implements Configurable, ModuleComponent
   }
 
   @Override
-  public void apply() throws ConfigurationException {
+  public void apply() {
     Settings settings = this.toSettings();
     ModuleSettings projectSettingsComponent = ModuleSettings.getInstance(myModule);
     projectSettingsComponent.loadState(settings);

--- a/src/main/java/org/intellij/sonar/configuration/module/ModuleSonarServersView.java
+++ b/src/main/java/org/intellij/sonar/configuration/module/ModuleSonarServersView.java
@@ -42,8 +42,8 @@ public class ModuleSonarServersView extends SonarServersView {
 
   @Override
   protected boolean editAndRemoveButtonsCanBeEnabled() {
-    final boolean isNoSonarSelected = NO_SONAR.equals(mySonarServersComboBox.getSelectedItem().toString());
-    final boolean isProjectSonarSelected = PROJECT.equals(mySonarServersComboBox.getSelectedItem().toString());
+    final boolean isNoSonarSelected = NO_SONAR.equals(String.valueOf(mySonarServersComboBox.getSelectedItem()));
+    final boolean isProjectSonarSelected = PROJECT.equals(String.valueOf(mySonarServersComboBox.getSelectedItem()));
     return !isNoSonarSelected && !isProjectSonarSelected;
   }
 

--- a/src/main/java/org/intellij/sonar/configuration/partials/SonarServersView.java
+++ b/src/main/java/org/intellij/sonar/configuration/partials/SonarServersView.java
@@ -36,10 +36,11 @@ public abstract class SonarServersView {
     this.myEditSonarServerButton = myEditSonarServerButton;
     this.myRemoveSonarServerButton = myRemoveSonarServerButton;
     this.myProject = myProject;
+
+    addActionListenersForButtons();
   }
 
   public void init() {
-    addActionListenersForButtons();
     initSonarServersComboBox();
     disableEditAndRemoveButtonsIfPossible();
   }
@@ -53,6 +54,7 @@ public abstract class SonarServersView {
   }
 
   protected abstract boolean editAndRemoveButtonsCanBeEnabled();
+
   protected abstract void initSonarServersComboBox();
 
   protected void disableEditAndRemoveButtonsIfPossible() {
@@ -73,7 +75,7 @@ public abstract class SonarServersView {
     return dlg;
   }
 
-  protected void addActionListenersForButtons() {
+  protected final void addActionListenersForButtons() {
     addItemListenerForSonarServersComboBox();
     addActionListenerForAddSonarServerButton();
     addActionListenerForEditSonarServerButton();

--- a/src/main/java/org/intellij/sonar/configuration/project/ProjectSettingsConfigurable.java
+++ b/src/main/java/org/intellij/sonar/configuration/project/ProjectSettingsConfigurable.java
@@ -138,7 +138,7 @@ public class ProjectSettingsConfigurable implements Configurable, ProjectCompone
   }
 
   @Override
-  public void apply() throws ConfigurationException {
+  public void apply() {
     myProjectSettings.loadState(this.toSettings());
     mySonarConsoleSettings.loadState(this.toSonarConsoleSettings());
   }

--- a/src/main/java/org/intellij/sonar/console/SonarToolWindowFactory.java
+++ b/src/main/java/org/intellij/sonar/console/SonarToolWindowFactory.java
@@ -30,5 +30,6 @@ public class SonarToolWindowFactory implements ToolWindowFactory {
 
   @Override
   public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
+    SonarConsole.get(project).info("Use Analyze -> Inspect Code to update Issues from SonarServer.");
   }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -4,7 +4,7 @@
     <id>org.mayevskiy.intellij.sonar</id>
     <name>SonarQube Community Plugin</name>
 
-    <version>2.8.4</version>
+    <version>2.9.0</version>
 
     <vendor email="sonarqube-intellij-plugin@googlegroups.com"
             url="https://github.com/sonar-intellij-plugin/sonar-intellij-plugin">
@@ -16,6 +16,13 @@
 
     <change-notes>
         <![CDATA[
+<p>
+2.9.0
+<ul>
+<li>Provides SonarServer Inspection for IntelliJ 2020.1</li>
+</ul>
+</p>
+<p>
 <p>
 2.8.4
 <ul>
@@ -264,7 +271,7 @@
     </change-notes>
 
     <!-- see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html -->
-    <idea-version since-build="193" /> <!-- IntelliJ IDEA v.2019.3 -->
+    <idea-version since-build="201.6668" /> <!-- IntelliJ IDEA v.2020.1-->
 
     <depends>com.intellij.modules.lang</depends>
 
@@ -302,13 +309,16 @@
                 org.intellij.sonar.persistence.ModuleSettings
             </implementation-class>
         </component>
+        <component>
+            <implementation-class>
+                org.intellij.sonar.configuration.module.ModuleSettingsConfigurable
+            </implementation-class>
+        </component>
     </module-components>
 
     <extensions defaultExtensionNs="com.intellij">
         <projectConfigurable id="projectSettingsConfigurable"
                              instance="org.intellij.sonar.configuration.project.ProjectSettingsConfigurable"/>
-        <moduleConfigurable id="moduleSettingsConfigurable"
-                            instance="org.intellij.sonar.configuration.module.ModuleSettingsConfigurable"/>
         <applicationService
                 serviceImplementation="org.intellij.sonar.persistence.SonarServers"/>
         <applicationService


### PR DESCRIPTION
updated Version for compatibility with IntelliJ 2020.1; added a hint how to get Sonar-Issues so the SonarQube ToolWindow ist not empty on startup.

I have not tested or modified the local analysis.
The sonar.analysis.mode setting is deprecated (afaik since Sonar 6.6) and not anymore available since Sonar 7.7.